### PR TITLE
fix CMakeLists.txt for cheetah_lib

### DIFF
--- a/cheetah_lib/CMakeLists.txt
+++ b/cheetah_lib/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cheetah_lib)
 
+find_package(catkin)
 set(CHEETAH_VERSION v3.05)
 set(TARBALL_NAME cheetah-library-${CHEETAH_VERSION})
 


### PR DESCRIPTION
Without the find_package directive, catkin_make_isolated fails to find
the catkin_package macro